### PR TITLE
Use shareous1 for EU Dexcom accounts. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To synchronize from Dexcom Share use the following variables.
 Optional, `CONNECT_SHARE_REGION` and `CONNECT_SHARE_SERVER` do the same thing, only specify one.
 * `CONNECT_SHARE_REGION=`  `ous` or `us`. `us` is the default if nothing is
   provided.  Selecting `us` sets `CONNECT_SHARE_SERVER` to `share2.dexcom.com`.
-  Selecting `ous` here sets `CONNECT_SHARE_SERVER` to `shareous2.dexcom.com`.
+  Selecting `ous` here sets `CONNECT_SHARE_SERVER` to `shareous1.dexcom.com`.
 * `CONNECT_SHARE_SERVER=` set the server domain to use.
 
 

--- a/lib/sources/dexcomshare.js
+++ b/lib/sources/dexcomshare.js
@@ -6,7 +6,7 @@ var software = require('../../package.json');
 var user_agent_string = [software.name, `${software.name}@${software.version}`, '"Dexcom Share"', software.homepage].join(', ');
 
 var _known_servers = {
-  ous: 'shareous2.dexcom.com',
+  ous: 'shareous1.dexcom.com',
   us: 'share2.dexcom.com'
 }
 


### PR DESCRIPTION
The current docs of NS dev says to use shareous2, which does not work. 
shareous1 has been confirmed to work using CONNECT_SHARE_SERVER: shareous1.dexcom.com with current NS dev.

Please see https://github.com/nightscout/cgm-remote-monitor/issues/5795 for a related, previous issue.