### PR TITLE
fix: Fixing Libre Linkup Crash

### DIFF
--- a/lib/sources/librelinkup.js
+++ b/lib/sources/librelinkup.js
@@ -121,7 +121,7 @@ function linkUpSource (opts, axios) {
       var { status, data, ticket } = payload;
       var batch = data;
       // TODO: TRANSFORM
-      var last_updated = last_known.entries;
+      var last_updated = (last_known && last_known.entries) ? last_known.entries : null;
       function is_newer (elem) {
         if (!last_known) { return true; };
         return last_known.entries < new Date(elem.dateString);


### PR DESCRIPTION
### Description

When the connect plugin pulls data for Libre LinkUp, if `last_known` is `null`, the plugin crashes with the following error, causing a reboot loop on the container: 

```js
 /opt/app/node_modules/nightscout-connect/lib/sources/librelinkup.js:124
       var last_updated = last_known.entries;
                                     ^

 TypeError: Cannot read properties of null (reading 'entries')
     at Object.transformGlucose [as transformer] (/opt/app/node_modules/nightscout-connect/lib/sources/librelinkup.js:124:37)
     at transformService (/opt/app/node_modules/nightscout-connect/lib/machines/fetch.js:14:37)
     at Interpreter._exec (/opt/app/node_modules/xstate/lib/interpreter.js:269:63)
     at Interpreter.exec (/opt/app/node_modules/xstate/lib/interpreter.js:1026:10)
     at Interpreter.execute (/opt/app/node_modules/xstate/lib/interpreter.js:387:14)
     at Interpreter.update (/opt/app/node_modules/xstate/lib/interpreter.js:415:12)
     at /opt/app/node_modules/xstate/lib/interpreter.js:110:15
     at Scheduler.process (/opt/app/node_modules/xstate/lib/scheduler.js:69:7)
     at Scheduler.schedule (/opt/app/node_modules/xstate/lib/scheduler.js:48:10)
     at Interpreter.send (/opt/app/node_modules/xstate/lib/interpreter.js:104:23)
```

This is fixed by adding in appropriate checks to ensure that direct reference to an `undefined` var are not performed and thus prevents the system from crashing. 

fixes: #27 