### PR TITLE
Fix linkup reporting delay

### DIFF
--- a/lib/sources/librelinkup.js
+++ b/lib/sources/librelinkup.js
@@ -141,7 +141,8 @@ function linkUpSource (opts, axios) {
         };
       }
 
-      var entries = batch.graphData.map(to_ns_sgv).filter(is_newer);
+      // add current value to the list to avoid 20min delay, remove filtering since NS automatically removes duplicates
+      var entries = batch.graphData.concat([batch.connection.glucoseItem]).map(to_ns_sgv);
       var treatments = [ ];
       var devicestatus = [ ];
       var profiles = [ ];


### PR DESCRIPTION
Fix the ~20min delay when importing glucose measurements from LinkUp

It appears Libre intentionally cuts the last 20 minutes, but does provide the latest value. This fix simple injects the latest value into the graph data stream and removes the filtering. The filter removal is required to allow the recovery of any missing 20 minute period missing at a restart - using the latest timestamp prevents bringing in data from any missing period prior to any imported value. Upon testing, I can confirm that NS does not maintain duplicates, the mongodb data only shows one value of each, so the filtering seems to be unnecessary either way and can only create issues.