### PR TITLE
Glooko: fix broken fetcher

### DIFF
--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -107,15 +107,17 @@ function glookoSource (opts, axios) {
       };
 
       function fetcher (endpoint) {
-        var headers = default_headers;
-        headers["Cookie"] = session.cookies;
-        headers["Host"] = "eu.api.glooko.com";
-        headers["Sec-Fetch-Dest"] = "empty";
-        headers["Sec-Fetch-Mode"] = "cors";
-        headers["Sec-Fetch-Site"] = "same-site";
         console.log('GLOOKO FETCHER LOADING', endpoint);
-        return http.get(endpoint, { headers, params })
-          .then((resp) => resp.data);
+        var headers = {
+          'Cookie': session.cookies,
+        };
+        return http.get(endpoint, {
+          baseURL: baseURL,
+          headers: headers,
+          params: params
+        })
+          .then((resp) => resp.data)
+          .catch((error) => console.error(error));
       }
 
       // 2023-06-11T00:00:00.000Z


### PR DESCRIPTION
The fetcher currently fails with `HTTP 432 Request does not satisfy rule conditions`.

This change removes then unneeded request headers and passes request data to Axios using named object fields.

This change was manually tested using the following commands:

```
$ npm install

$ export CONNECT_NIGHTSCOUT_ENDPOINT=...
$ export CONNECT_API_SECRET=[redacted]

$ export CONNECT_SOURCE=glooko
$ export CONNECT_GLOOKO_EMAIL=[redacted]
$ export CONNECT_GLOOKO_PASSWORD=[redacted]
$ export CONNECT_GLOOKO_TIMEZONE_OFFSET=[redacted]

$ mkdir -p logs/
$ ./bin/nightscout-connect capture logs --source glooko
```