### PR TITLE
Extract a Glooko API client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*.sw[po]
 node_modules/
+logs/

--- a/lib/sources/glooko/api.js
+++ b/lib/sources/glooko/api.js
@@ -1,0 +1,239 @@
+/**
+ * This module implements a client for Glooko's REST API.  It is used by
+ * the Glooko source module to authenticate with and fetch data from
+ * Glooko's servers.
+ */
+
+const axios = require('axios');
+const tough = require('tough-cookie');
+
+// The Glooko host URL that REST API endpoints are relative to
+const baseUrl = (() => {
+
+  // api.glooko.com by default, or eu.api.glooko.com for EU users.
+  const glookoServerSetting =
+    process.env['CONNECT_GLOOKO_SERVER'] || 'default';
+
+  const glookoServer =
+    glookoServerSetting === 'default' ?
+    'api.glooko.com' :
+    glookoServerSetting;
+
+  return `https://${glookoServer}`;
+})();
+
+// A reusable HTTP client with common settings configured
+const http = axios.create({
+  baseURL: baseUrl
+  , maxRedirects: 0
+  , headers: {
+    'Accept': 'application/json'
+    , 'User-Agent': 'Mozilla/5.0 (compatible; nightscout-connect; +https://github.com/nightscout/nightscout-connect)'
+  }
+});
+
+
+/**
+ * Signs into a Glooko account using an email address and password to
+ * retrieve a session cookie.
+ *
+ * @param {string} email     The Glooko account's email address
+ * @param {string} password  The Glooko account's password
+ *
+ * @return {promise<string>} A promise containing a session cookie
+ */
+const createSession = (email, password) => {
+
+  const requestBody = {
+    "userLogin": {
+      "email": email
+      , "password": password
+    }
+    , "deviceInformation": {
+      "applicationType": "logbook"
+      , "os": "android"
+      , "osVersion": "33"
+      , "device": "Google Pixel 4a"
+      , "deviceManufacturer": "Google"
+      , "deviceModel": "Pixel 4a"
+      , "serialNumber": "ab43bfjdj3423421fb"
+      , "clinicalResearch": false
+      , "deviceId": "716c34bac673f4b9"
+      , "applicationVersion": "6.1.3"
+      , "buildNumber": "0"
+      , "gitHash": "g4fbed2011b"
+    }
+  };
+
+  return http.post(
+      '/api/v2/users/sign_in'
+      , requestBody
+      , {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+    .then((response) => {
+      const sessionCookie =
+        (response.headers['set-cookie'] || [])
+        .map(tough.parse)
+        .map((x) => x.cookieString())
+        .join('; ');
+      return sessionCookie;
+    })
+    .catch((error) => {
+      console.error('Glooko API: Error signing in', error)
+    });
+};
+
+/**
+ * Retrieves a patient's identifier to use with Glooko's data retrieval
+ * APIs.
+ *
+ * @param {string} cookie    The session cookie
+ *
+ * @return {promise<string>} The patient's identifier
+ */
+const getGlookoCode = (cookie) => {
+  return http.get('/api/v3/session/users', {
+      headers: {
+        'Cookie': cookie
+        , 'Accept': 'application/json'
+      , }
+    , })
+    .then(function(response) {
+      return response.data.currentPatient.glookoCode;
+    })
+    .catch(function(error) {
+      console.error('Glooko API: Error retrieving session info', error);
+    });
+};
+
+/**
+ * Signs into a Glooko account using an email address and password and
+ * retrieves both a session cookie and a patient's identifier to use
+ * with Glooko's data retrieval APIs.
+ *
+ * @param {string} email     The Glooko account's email address
+ * @param {string} password  The Glooko account's password
+ *
+ * @return {promise<session>} A promise containing an object containing
+ *     the session cookie and the patient's identifier
+ */
+const signIn = (email, password) => {
+  return createSession(email, password)
+    .then((cookie) => {
+      return getGlookoCode(cookie)
+        .then((glookoCode) => {
+          return {
+            cookie: cookie
+            , glookoCode: glookoCode
+          };
+        });
+    });
+};
+
+/**
+ * Retrieves data from the given Glooko API endpoint.
+ *
+ * @param {string} endpoint   The Glooko REST API endpoint to call
+ * @param {string} cookie     An authenticated session cookie
+ * @param {string} glookoCode A patient identifier
+ * @param {string} lastKnown  The time in milliseconds, of the last
+ *     time this data was retrieved (optional)
+ *
+ * @return {promise<object>}  The raw response data from Glooko
+ */
+const fetch = (endpoint, cookie, glookoCode, lastKnown) => {
+
+  // This is a hardcoded, random guid; there are no Glooko docs to
+  // explain the need for this param or why random data works
+  const lastGuid = "1e0c094e-1e54-4a4f-8e6a-f94484b53789"
+
+  const twoDaysAgo = new Date().getTime() - (2 * 24 * 60 * 60 * 1000);
+  var lastMillis = Math.max(twoDaysAgo, (lastKnown && lastKnown.entries) ? lastKnown.entries.getTime() : twoDaysAgo);
+  var lastGlucoseAt = new Date(lastMillis);
+  var maxCount = Math.ceil(((new Date()).getTime() - lastMillis) / (1000 * 60 * 5));
+  var minutes = 5 * maxCount;
+  var lastUpdatedAt = lastGlucoseAt.toISOString();
+  var body = {};
+  var params = {
+    lastGuid: lastGuid
+    , lastUpdatedAt
+    , limit: maxCount
+  , };
+
+  const myDate = new Date();
+  const startDate = new Date(twoDaysAgo);
+
+  const url = `${endpoint}?patient=${glookoCode}&startDate=${startDate.toISOString()}&endDate=${myDate.toISOString()}`;
+
+  var requestHeaders = {
+    'Cookie': cookie
+  };
+
+  return axios
+    .get(url, {
+      baseURL: baseUrl
+      , headers: requestHeaders
+      , params: params
+    })
+    .then((resp) => resp.data)
+    .catch((error) => console.error('Glooko API: Axios error', error));
+};
+
+/**
+ * Retrieves CGM readings from Glooko.
+ *
+ * @param {string} cookie     An authenticated session cookie
+ * @param {string} glookoCode A patient identifier
+ * @param {string} lastKnown  The time in milliseconds, of the last
+ *     time this data was retrieved (optional)
+ *
+ * @return {promise<object>}  The raw CGM readings data from Glooko
+ */
+const getCgmReadings = (cookie, glookoCode, lastKnown) => {
+  return fetch('/api/v2/cgm/readings', cookie, glookoCode, lastKnown);
+};
+
+/**
+ * Retrieves normal boluses from Glooko.
+ *
+ * @param {string} cookie     An authenticated session cookie
+ * @param {string} glookoCode A patient identifier
+ * @param {string} lastKnown  The time in milliseconds, of the last
+ *     time this data was retrieved (optional)
+ *
+ * @return {promise<object>}  The raw boluses data from Glooko
+ */
+const getNormalBoluses = (cookie, glookoCode, lastKnown) => {
+  return fetch('/api/v2/pumps/normal_boluses', cookie, glookoCode, lastKnown);
+};
+
+/**
+ * Retrieves scheduled basals from Glooko.
+ *
+ * @param {string} cookie     An authenticated session cookie
+ * @param {string} glookoCode A patient identifier
+ * @param {string} lastKnown  The time in milliseconds, of the last
+ *     time this data was retrieved (optional)
+ *
+ * @return {promise<object>}  The raw basals data from Glooko
+ */
+const getScheduledBasals = (cookie, glookoCode, lastKnown) => {
+  return fetch('/api/v2/pumps/scheduled_basals', cookie, glookoCode, lastKnown);
+};
+
+/**
+ * This module exports the sign-in and data retrieval endpoints, as well
+ * as the http client so it can be passed to the Axios tracer for
+ * tracking.
+ */
+module.exports = {
+  signIn: signIn
+  , getCgmReadings: getCgmReadings
+  , getNormalBoluses: getNormalBoluses
+  , getScheduledBasals: getScheduledBasals
+  , http: http
+};

--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -13,164 +13,38 @@ var url = require('url');
 var uid = require('uid');
 
 var helper = require('./convert');
+const glookoApi = require('./api.js');
 
-_known_servers = {
-  default: 'api.glooko.com'
-, development: 'api.glooko.work'
-, production: 'externalapi.glooko.com'
-, eu: 'eu.api.glooko.com'
-};
-
-var Defaults = {
-  "applicationId":"d89443d2-327c-4a6f-89e5-496bbb0317db"
-, "lastGuid":"1e0c094e-1e54-4a4f-8e6a-f94484b53789" // hardcoded, random guid; no Glooko docs to explain need for param or why bad data works
-, login: '/api/v2/users/sign_in'
-, mime: 'application/json'
-, LatestFoods: '/api/v2/foods'
-, LatestInsulins: '/api/v2/insulins'
-, LatestPumpBasals: '/api/v2/pumps/scheduled_basals'
-, LatestPumpBolus: '/api/v2/pumps/normal_boluses'
-, LatestCGMReadings: '/api/v2/cgm/readings'
-, PumpSettings: '/api/v2/external/pumps/settings'
-, v3API: '/api/v3/graph/data?patient=_PATIENT_&startDate=_STARTDATE_&endDate=_ENDDATE_&series[]=automaticBolus&series[]=basalBarAutomated&series[]=basalBarAutomatedMax&series[]=basalBarAutomatedSuspend&series[]=basalLabels&series[]=basalModulation&series[]=bgAbove400&series[]=bgAbove400Manual&series[]=bgHigh&series[]=bgHighManual&series[]=bgLow&series[]=bgLowManual&series[]=bgNormal&series[]=bgNormalManual&series[]=bgTargets&series[]=carbNonManual&series[]=cgmCalibrationHigh&series[]=cgmCalibrationLow&series[]=cgmCalibrationNormal&series[]=cgmHigh&series[]=cgmLow&series[]=cgmNormal&series[]=deliveredBolus&series[]=deliveredBolus&series[]=extendedBolusStep&series[]=extendedBolusStep&series[]=gkCarb&series[]=gkInsulin&series[]=gkInsulin&series[]=gkInsulinBasal&series[]=gkInsulinBolus&series[]=gkInsulinOther&series[]=gkInsulinPremixed&series[]=injectionBolus&series[]=injectionBolus&series[]=interruptedBolus&series[]=interruptedBolus&series[]=lgsPlgs&series[]=overrideAboveBolus&series[]=overrideAboveBolus&series[]=overrideBelowBolus&series[]=overrideBelowBolus&series[]=pumpAdvisoryAlert&series[]=pumpAlarm&series[]=pumpBasaliqAutomaticMode&series[]=pumpBasaliqManualMode&series[]=pumpCamapsAutomaticMode&series[]=pumpCamapsBluetoothTurnedOffMode&series[]=pumpCamapsBoostMode&series[]=pumpCamapsDailyTotalInsulinExceededMode&series[]=pumpCamapsDepoweredMode&series[]=pumpCamapsEaseOffMode&series[]=pumpCamapsExtendedBolusNotAllowedMode&series[]=pumpCamapsManualMode&series[]=pumpCamapsNoCgmMode&series[]=pumpCamapsNoPumpConnectivityMode&series[]=pumpCamapsPumpDeliverySuspendedMode&series[]=pumpCamapsUnableToProceedMode&series[]=pumpControliqAutomaticMode&series[]=pumpControliqExerciseMode&series[]=pumpControliqManualMode&series[]=pumpControliqSleepMode&series[]=pumpGenericAutomaticMode&series[]=pumpGenericManualMode&series[]=pumpOp5AutomaticMode&series[]=pumpOp5HypoprotectMode&series[]=pumpOp5LimitedMode&series[]=pumpOp5ManualMode&series[]=reservoirChange&series[]=scheduledBasal&series[]=setSiteChange&series[]=suggestedBolus&series[]=suggestedBolus&series[]=suspendBasal&series[]=temporaryBasal&series[]=unusedScheduledBasal&locale=en-GB'
-// ?sessionID=e59c836f-5aeb-4b95-afa2-39cf2769fede&minutes=1440&maxCount=1"
-};
-
-function base_for (spec) {
-  var server = spec.glookoServer ? spec.glookoServer : _known_servers[spec.glookoEnv || 'default' ];
-  var base = {
-    protocol: 'https',
-    host: server
-  };
-  return url.format(base);
-}
-
-function login_payload (opts) {
-  var body = {
-    "userLogin": {
-      "email": opts.glookoEmail,
-      "password": opts.glookoPassword
-    },
-    "deviceInformation": {
-      "applicationType": "logbook",
-      "os": "android",
-      "osVersion": "33",
-      "device": "Google Pixel 4a",
-      "deviceManufacturer": "Google",
-      "deviceModel": "Pixel 4a",
-      "serialNumber": "ab43bfjdj3423421fb",
-      "clinicalResearch": false,
-      "deviceId": "716c34bac673f4b9",
-      "applicationVersion": "6.1.3",
-      "buildNumber": "0",
-      "gitHash": "g4fbed2011b"
-    }
-  };
-  return body;
-}
 function glookoSource (opts, axios) {
-  var default_headers = { 'Content-Type': Defaults.mime,
-                          'Accept': 'application/json, text/plain, */*',
-                          'Accept-Encoding': 'gzip, deflate, br',
-                          'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15',
-                          'Referer': 'https://eu.my.glooko.com/',
-                          'Origin': 'https://eu.my.glooko.com',
-                          'Connection': 'keep-alive',
-                          'Accept-Language': 'en-GB,en;q=0.9'
-                          };
-  var baseURL = opts.baseURL;
-  //console.log('GLOOKO OPTS', opts);
-  var http = axios.create({ baseURL, headers: default_headers });
   var impl = {
     authFromCredentials ( ) {
-      var payload = login_payload(opts);
-      return http.post(Defaults.login, payload).then((response) => {
-        console.log("GLOOKO AUTH", response.headers, response.data);
-        return { cookies: response.headers['set-cookie'][0], user: response.data };
-      });
+      return glookoApi
+        .signIn(opts.glookoEmail, opts.glookoPassword)
+        .then((session) => {
+          return {
+            cookies: session.cookie,
+            user: {
+              userLogin: {
+                glookoCode: session.glookoCode
+              }
+            }
+          };
+        });
     },
     sessionFromAuth (auth) {
       return Promise.resolve(auth);
     },
     dataFromSesssion (session, last_known) {
-      var two_days_ago = new Date( ).getTime( ) - (2 * 24 * 60 * 60 * 1000);
-      var last_mills = Math.max(two_days_ago, (last_known && last_known.entries) ? last_known.entries.getTime( ) : two_days_ago);
-      var last_glucose_at = new Date(last_mills);
-      var maxCount = Math.ceil(((new Date( )).getTime( ) - last_mills) / (1000 * 60 * 5));
-      var minutes = 5 * maxCount;
-      var lastUpdatedAt = last_glucose_at.toISOString( );
-      var body = { };
-      var params = {
-        lastGuid: Defaults.lastGuid,
-        lastUpdatedAt,
-        limit: maxCount,
-      };
-
-      function fetcher (endpoint) {
-        var headers = default_headers;
-        headers["Cookie"] = session.cookies;
-        headers["Host"] = "eu.api.glooko.com";
-        headers["Sec-Fetch-Dest"] = "empty";
-        headers["Sec-Fetch-Mode"] = "cors";
-        headers["Sec-Fetch-Site"] = "same-site";
-        console.log('GLOOKO FETCHER LOADING', endpoint);
-        return http.get(endpoint, { headers, params })
-          .then((resp) => resp.data);
-      }
-
-      // 2023-06-11T00:00:00.000Z
-      // 2023-06-11T23:59:59.999Z
-
-      const myDate = new Date();
-      const dateString = myDate.getFullYear() + '-'
-         + ('0' + (myDate.getMonth()+1)).slice(-2) + '-'
-        + ('0' + myDate.getDate()).slice(-2);
-
-      /*
-      console.log('SESSION USER', session.user);
-      let v3APIURL = Defaults.v3API.replace('_PATIENT_',session.user.userLogin.glookoCode).replace('_STARTDATE_', dateString + "T00:00:00.000Z").replace('_ENDDATE_', dateString + 'T23:59:59.999Z');
-      */      
-      function constructUrl(endpoint) {
-        //?patient=orange-waywood-8651&startDate=2020-01-08T06:07:00.000Z&endDate=2020-01-09T06:07:00.000Z
-        const myDate = new Date();
-        const startDate = new Date(two_days_ago); // myDate.getTime() - 6 * 60 * 60 * 1000);
-
-        const url = endpoint + "?patient=" + session.user.userLogin.glookoCode
-         + "&startDate=" + startDate.toISOString()
-         + "&endDate=" + myDate.toISOString();
-
-        return url;
-      }
-
       return Promise.all([
-        //fetcher(v3APIURL)
-        //fetcher(constructUrl(Defaults.LatestFoods)),
-        //fetcher(constructUrl(Defaults.LatestInsulins)),
-        fetcher(constructUrl(Defaults.LatestPumpBasals)),
-        fetcher(constructUrl(Defaults.LatestPumpBolus)),
-        fetcher(constructUrl(Defaults.LatestCGMReadings)),
-        //fetcher(constructUrl(Defaults.PumpSettings))
+        glookoApi.getScheduledBasals(last_known),
+        glookoApi.getNormalBoluses(last_known),
+        glookoApi.getCgmReadings(last_known),
         ]).then(function (results) {
-          //console.log(results);
-         var some = {
-            //food: results[0].foods,
-            //insulins: results[1].insulins,
-            scheduledBasals: results[0].scheduledBasals,
-            normalBoluses: results[1].normalBoluses,
-            readings: results[2].readings
-            //settings: results[4].pumpSettings
+         return {
+           scheduledBasals: results[0].scheduledBasals
+           , normalBoluses: results[1].normalBoluses
+           , readings: results[2].readings
          };
-
-         //console.log('food sample', JSON.stringify(some.food[0]));
-         //console.log('insulins sample', JSON.stringify(some.insulins[0]));
-         //console.log('scheduledBasals sample', JSON.stringify(some.scheduledBasals[0]));
-         //console.log('normalBoluses sample', JSON.stringify(some.normalBoluses[0]));
-         //console.log('readings sample', JSON.stringify(some.readings[0]));
-         //console.log('settings sample', JSON.stringify(results[4]));
-
-          //console.log('GLOOKO DATA FETCH', results, some);
-          //console.log('GOT RESULTS FROM GLOOKO', results);
-          return some;
         });
     },
     align_to_glucose ( ) {
@@ -185,10 +59,8 @@ function glookoSource (opts, axios) {
     },
   };
   function tracker_for ( ) {
-    // var { AxiosHarTracker } = require('axios-har-tracker');
-    // var tracker = new AxiosHarTracker(http);
     var AxiosTracer = require('../../trace-axios');
-    var tracker = AxiosTracer(http);
+    var tracker = AxiosTracer(glookoApi.http);
     return tracker;
   }
   function generate_driver (builder) {
@@ -231,7 +103,6 @@ function glookoSource (opts, axios) {
 
 glookoSource.validate = function validate_inputs (input) {
   var ok = false;
-  var baseURL = base_for(input);
 
   const offset = !isNaN(input.glookoTimezoneOffset) ? input.glookoTimezoneOffset * -60 * 60 * 1000 : 0
   console.log('GLOOKO using ms offset:', offset, input.glookoTimezoneOffset);
@@ -242,7 +113,6 @@ glookoSource.validate = function validate_inputs (input) {
     glookoEmail: input.glookoEmail,
     glookoPassword: input.glookoPassword,
     glookoTimezoneOffset: offset,
-    baseURL
   };
   var errors = [ ];
   if (!config.glookoEmail) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "nightscout-connect": "bin/nightscout-connect"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --recursive",
+    "fmt": "find lib test -type f -name \"api.js\" -exec js-beautify -r --indent-size 2 --comma-first --keep-array-indentation {} \\;"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,8 @@
   "license": "AGPL-3.0-or-later",
   "devDependencies": {
     "axios-har-tracker": "^0.5.1",
+    "js-beautify": "^1.15.4",
+    "mocha": "^11.7.1",
     "moment": "^2.29.4"
   },
   "peerDependencies": {

--- a/test/sources/glooko/api.js
+++ b/test/sources/glooko/api.js
@@ -1,0 +1,87 @@
+/**
+ * This file tests the Glooko REST API client implementation, maintained
+ * in `lib/sources/glooko/api.js`, in isolation from the rest of the
+ * project's components.
+ */
+const glookoApi = require('../../../lib/sources/glooko/api.js');
+const assert = require('assert');
+
+describe('Glooko API', () => {
+
+  var session = null;
+
+  /**
+   * Sign in to Glooko using the standard `CONNECT_GLOOKO_EMAIL` and
+   * `CONNECT_GLOOKO_PASSWORD` environment variables, and make sure we
+   * get back a session with both a cookie and a patient identifier.
+   *
+   * Save the session for use in the data retrieval tests below.
+   */
+  describe('signIn()', () => {
+    it('should create a valid session', () => {
+
+      const glookoEmail = process.env['CONNECT_GLOOKO_EMAIL'];
+      assert.ok(glookoEmail, 'CONNECT_GLOOKO_EMAIL must be set');
+
+      const glookoPassword = process.env['CONNECT_GLOOKO_PASSWORD'];
+      assert.ok(glookoPassword, 'CONNECT_GLOOKO_PASSWORD must be set');
+
+      return glookoApi
+        .signIn(glookoEmail, glookoPassword)
+        .then((x) => {
+          session = x;
+        }).then(() => {
+          assert.ok(session.cookie.startsWith('_logbook-web_session='));
+          assert.ok(session.glookoCode.length > 0);
+          return session;
+        });
+    });
+  });
+
+  const lastKnown = null;
+
+  /**
+   * Retrieve CGM readings from Glooko using the session created above.
+   */
+  describe('getCgmReadings()', () => {
+    it('should retrieve cgm readings', () => {
+      assert.ok(session, 'session must be valid');
+      return glookoApi
+        .getCgmReadings(session.cookie, session.glookoCode, lastKnown)
+        .then((result) => {
+          assert.ok(Array.isArray(result.readings));
+        });
+    });
+  });
+
+  /**
+   * Retrieve normal boluses from Glooko using the session created
+   * above.
+   */
+  describe('getNormalBoluses()', () => {
+    it('should retrieve normal boluses', () => {
+      assert.ok(session, 'session must be valid');
+      return glookoApi
+        .getNormalBoluses(session.cookie, session.glookoCode, lastKnown)
+        .then((result) => {
+          assert.ok(Array.isArray(result.normalBoluses));
+        });
+    });
+  });
+
+  /**
+   * Retrieve scheduled basals from Glooko using the session created
+   * above.
+   */
+  describe('getScheduledBasals()', () => {
+    it('should retrieve scheduled basals', () => {
+      assert.ok(session, 'session must be valid');
+      return glookoApi
+        .getScheduledBasals(session.cookie, session.glookoCode, lastKnown)
+        .then((result) => {
+          assert.ok(Array.isArray(result.scheduledBasals));
+        });
+    });
+  });
+
+});


### PR DESCRIPTION
This adds a client for the Glooko REST API.  The code was extracted from `lib/sources/glooko/index.js`, and refactored into a decoupled module that can be tested in isolation from the rest of the project's components.

This adds Mocha as a dev dependency, and configures npm to run it via the `npm test` command.

This also adds js-beautify and a script that can be run via `npm run-script fmt` to apply the [cgm-remote-monitor style guide][1] to the two new `api.js` files.

[1]: https://github.com/nightscout/cgm-remote-monitor/blob/15.0.3/CONTRIBUTING.md#style-guide