### PR TITLE
Glooko CGM data retrieval fixed ! (needs work on timestamps/timezones)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+git add .
+git commit -m "puppeteer version"
+git push -u origin main

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 git add .
-git commit -m "puppeteer version"
+git commit -m "CGM, pump and treatment data from Glooko. Needs timestamp fixes"
 git push -u origin main

--- a/lib/sources/glooko/convert.js
+++ b/lib/sources/glooko/convert.js
@@ -48,7 +48,7 @@ function generate_nightscout_treatments(batch, timestampDelta) {
         var i_date = moment(insulin.timestamp);
         treatment.eventType = 'Meal Bolus';
         // 4 hours * 60 minutes per hour * 60 seconds per minute * 1000 millseconds
-        treatment.eventTime = new Date(i_date ).toISOString( );
+        treatment.eventTime = i_date.toISOString( );
         //treatment.eventTime = new Date(i_date).toISOString( );
         //treatment.eventTime = i_date.toISOString( );
         treatment.insulin = insulin.value;
@@ -58,7 +58,7 @@ function generate_nightscout_treatments(batch, timestampDelta) {
       } else {
         var f_date = moment(element.timestamp);
         treatment.eventType = 'Carb Correction';
-        treatment.eventTime = new Date(f_date ).toISOString( );
+        treatment.eventTime = f_date.toISOString( );
         //treatment.eventTime = new Date(f_date).toISOString( );
         //treatment.eventTime = f_date.toISOString( );
       }
@@ -99,7 +99,7 @@ function generate_nightscout_treatments(batch, timestampDelta) {
       if (result[0] == undefined) {
         var f_date = moment(element.timestamp);
         treatment.eventType = 'Correction Bolus';
-        treatment.eventTime = new Date(f_date).toISOString( );
+        treatment.eventTime = f_date.toISOString( );
         treatment.insulin = element.value;
         //treatment.eventTime = f_date.toISOString( );
         treatments.push(treatment);
@@ -113,9 +113,11 @@ function generate_nightscout_treatments(batch, timestampDelta) {
 
       //console.log(element);
       
-      var f_date = moment(element.pumpTimestamp);
+      // Pump timestamps come in Finland time (UTC+3) but marked as UTC
+      // Convert to actual UTC by subtracting 3 hours
+      var f_date = moment(element.pumpTimestamp).subtract(3, 'hours');
       treatment.eventType = 'Meal Bolus';
-      treatment.eventTime = new Date(f_date + timestampDelta).toISOString( );
+      treatment.eventTime = new Date(f_date.toDate().getTime() + timestampDelta).toISOString( );
       treatment.insulin = element.insulinDelivered;
       treatment.carbs = element.carbsInput;
       treatment.notes = JSON.stringify(element);
@@ -159,9 +161,11 @@ function generate_nightscout_treatments(batch, timestampDelta) {
 
       //console.log(element);
       
-      var f_date = moment(element.pumpTimestamp);
+      // Basal timestamps come in Finland time (UTC+3) but marked as UTC
+      // Convert to actual UTC by subtracting 3 hours
+      var f_date = moment(element.pumpTimestamp).subtract(3, 'hours');
       treatment.eventType = 'Temp Basal';
-      treatment.created_at = new Date(f_date + timestampDelta).toISOString( );
+      treatment.created_at = new Date(f_date.toDate().getTime() + timestampDelta).toISOString( );
       treatment.rate = element.rate;
       treatment.absolute = element.rate;
       treatment.duration = element.duration / 60;
@@ -186,15 +190,17 @@ function generate_nightscout_entries(batch, timestampDelta) {
       
       // Convert timestamp to Nightscout format
       var date = moment(element.timestamp || element.pumpTimestamp);
-      entry.date = new Date(date + timestampDelta).getTime();
-      entry.dateString = new Date(date + timestampDelta).toISOString();
+      // Apply timezone delta and convert to JavaScript Date
+      var adjustedDate = new Date(date.toDate().getTime() + timestampDelta);
+      entry.date = adjustedDate.getTime();
+      entry.dateString = adjustedDate.toISOString();
       
-      // Convert glucose value (Glooko uses mmol/L, Nightscout typically uses mg/dL)
-      // Check if value needs conversion from mmol/L to mg/dL
+      // Convert glucose value from mmol/L to mg/dL
+      // Graph API values are in mmol/L, need conversion to mg/dL for Nightscout
       var glucoseValue = element.value || element.glucoseValue;
-      if (glucoseValue && glucoseValue < 30) {
-        // Likely mmol/L, convert to mg/dL
-        glucoseValue = Math.round(glucoseValue * 18.0182);
+      if (glucoseValue) {
+        // Convert from mmol/L to mg/dL using the same conversion as the working script
+        glucoseValue = Math.round(glucoseValue * 18.0143);
       }
       
       entry.sgv = glucoseValue;

--- a/lib/sources/glooko/convert.js
+++ b/lib/sources/glooko/convert.js
@@ -175,4 +175,50 @@ function generate_nightscout_treatments(batch, timestampDelta) {
 
   return treatments;
 }
+
+function generate_nightscout_entries(batch, timestampDelta) {
+  const readings = batch.readings;
+  var entries = [];
+  
+  if (readings && readings.length > 0) {
+    readings.forEach(function(element) {
+      var entry = {};
+      
+      // Convert timestamp to Nightscout format
+      var date = moment(element.timestamp || element.pumpTimestamp);
+      entry.date = new Date(date + timestampDelta).getTime();
+      entry.dateString = new Date(date + timestampDelta).toISOString();
+      
+      // Convert glucose value (Glooko uses mmol/L, Nightscout typically uses mg/dL)
+      // Check if value needs conversion from mmol/L to mg/dL
+      var glucoseValue = element.value || element.glucoseValue;
+      if (glucoseValue && glucoseValue < 30) {
+        // Likely mmol/L, convert to mg/dL
+        glucoseValue = Math.round(glucoseValue * 18.0182);
+      }
+      
+      entry.sgv = glucoseValue;
+      entry.type = 'sgv';
+      entry.device = 'glooko-' + (element.deviceModel || 'cgm');
+      
+      // Add trend information if available
+      if (element.trend) {
+        entry.trend = element.trend;
+      }
+      
+      // Add raw data as note for debugging
+      entry.notes = JSON.stringify(element);
+      
+      entries.push(entry);
+    });
+    
+    console.log('GLOOKO entries transformation complete, returning', entries.length, 'entries');
+  } else {
+    console.log('GLOOKO: No CGM readings found in batch');
+  }
+  
+  return entries;
+}
+
 module.exports.generate_nightscout_treatments = generate_nightscout_treatments;
+module.exports.generate_nightscout_entries = generate_nightscout_entries;

--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -10,6 +10,7 @@
 
 var qs = require('qs');
 var url = require('url');
+var puppeteer = null; // Lazy load puppeteer only if needed
 
 var helper = require('./convert');
 
@@ -23,7 +24,9 @@ _known_servers = {
 var Defaults = {
   "applicationId":"d89443d2-327c-4a6f-89e5-496bbb0317db"
 , "lastGuid":"1e0c094e-1e54-4a4f-8e6a-f94484b53789" // hardcoded, random guid; no Glooko docs to explain need for param or why bad data works
-, login: '/api/v2/users/sign_in'
+, loginForm: '/users/sign_in?locale=en'  // Web login form
+, login: '/users/sign_in'  // POST login with form data
+, apiLogin: '/api/v2/users/sign_in'  // Original API login (kept for reference)
 , mime: 'application/json'
 , LatestFoods: '/api/v2/foods'
 , LatestInsulins: '/api/v2/insulins'
@@ -44,6 +47,34 @@ function base_for (spec) {
   return url.format(base);
 }
 
+function web_base_for (spec) {
+  // For login, we need to use the web app, not API
+  var server = spec.glookoEnv === 'eu' ? 'eu.my.glooko.com' : 'my.glooko.com';
+  var base = {
+    protocol: 'https',
+    host: server
+  };
+  return url.format(base);
+}
+
+function extract_csrf_token(html) {
+  // Extract authenticity_token from login form HTML
+  const match = html.match(/name="authenticity_token" value="([^"]+)"/);
+  return match ? match[1] : null;
+}
+
+function form_login_payload (opts, csrf_token) {
+  // Create form data like the browser sends
+  const params = new URLSearchParams();
+  params.append('authenticity_token', csrf_token);
+  params.append('redirect_to', '');
+  params.append('language', 'en');
+  params.append('user[email]', opts.glookoEmail);
+  params.append('user[password]', opts.glookoPassword);
+  params.append('commit', 'Sign In');
+  return params.toString();
+}
+
 function login_payload (opts) {
   var body = {
     "userLogin": {
@@ -57,6 +88,11 @@ function login_payload (opts) {
   return body;
 }
 function glookoSource (opts, axios) {
+  // Check if patient ID is manually configured
+  if (opts.glookoPatientId) {
+    console.log("GLOOKO: Using manually configured patient ID:", opts.glookoPatientId);
+  }
+  
   var default_headers = { 'Content-Type': Defaults.mime,
                           'Accept': 'application/json, text/plain, */*',
                           'Accept-Encoding': 'gzip, deflate, br',
@@ -66,15 +102,229 @@ function glookoSource (opts, axios) {
                           'Connection': 'keep-alive',
                           'Accept-Language': 'en-GB,en;q=0.9'
                           };
-  var baseURL = opts.baseURL;
+  var baseURL = opts.baseURL;  // API base URL
+  var webURL = web_base_for(opts);  // Web app base URL for login
   //console.log('GLOOKO OPTS', opts);
   var http = axios.create({ baseURL, headers: default_headers });
+  var webHttp = axios.create({ baseURL: webURL, headers: default_headers });
+  
   var impl = {
     authFromCredentials ( ) {
-      var payload = login_payload(opts);
-      return http.post(Defaults.login, payload).then((response) => {
-        console.log("GLOOKO AUTH", response.headers, response.data);
-        return { cookies: response.headers['set-cookie'][0], user: response.data };
+      // Check if patient ID is manually configured first
+      if (opts.glookoPatientId) {
+        console.log("GLOOKO AUTH: Using manually configured patient ID, skipping Puppeteer");
+        return impl.authFromCredentialsLegacy();
+      }
+
+      console.log("GLOOKO AUTH: Using Puppeteer for automatic patient ID extraction");
+      
+      // Lazy load Puppeteer only when needed
+      if (!puppeteer) {
+        try {
+          puppeteer = require('puppeteer');
+        } catch (error) {
+          console.log("GLOOKO AUTH: Puppeteer not available, falling back to legacy method");
+          return impl.authFromCredentialsLegacy();
+        }
+      }
+
+      return (async () => {
+        let browser = null;
+        
+        try {
+          console.log("GLOOKO AUTH: Launching Puppeteer browser");
+          browser = await puppeteer.launch({ 
+            headless: true,
+            args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage']
+          });
+          
+          const page = await browser.newPage();
+          
+          // Set user agent to match real browser
+          await page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36');
+          
+          console.log("GLOOKO AUTH: Navigating to login page");
+          const loginURL = webURL + '/users/sign_in?locale=en';
+          await page.goto(loginURL, { waitUntil: 'networkidle2' });
+          
+          console.log("GLOOKO AUTH: Filling login form");
+          await page.waitForSelector('input[name="user[email]"]', { timeout: 10000 });
+          await page.type('input[name="user[email]"]', opts.glookoEmail);
+          await page.type('input[name="user[password]"]', opts.glookoPassword);
+          
+          console.log("GLOOKO AUTH: Submitting login form");
+          await page.click('input[type="submit"], button[type="submit"]');
+          
+          // Wait for login to complete - look for dashboard elements or redirects
+          try {
+            await page.waitForNavigation({ waitUntil: 'networkidle2', timeout: 15000 });
+          } catch (navError) {
+            console.log("GLOOKO AUTH: Navigation timeout, checking if we're logged in anyway");
+          }
+          
+          // Check if we're on the dashboard or logged in successfully
+          const currentURL = page.url();
+          console.log("GLOOKO AUTH: Current URL after login:", currentURL);
+          
+          if (currentURL.includes('/users/sign_in')) {
+            throw new Error('Login failed - still on sign in page');
+          }
+          
+          console.log("GLOOKO AUTH: Extracting patient ID from JavaScript");
+          
+          // Extract patient ID from window.patient or similar JavaScript variables
+          const patientId = await page.evaluate(() => {
+            // Try multiple sources for the patient ID
+            if (typeof window.patient !== 'undefined') {
+              return window.patient;
+            }
+            if (typeof window.current_user_glooko_code !== 'undefined') {
+              return window.current_user_glooko_code;
+            }
+            if (typeof window.analyticsUser !== 'undefined' && window.analyticsUser.glooko_code) {
+              return window.analyticsUser.glooko_code;
+            }
+            if (typeof window.userData !== 'undefined' && window.userData.glookoCode) {
+              return window.userData.glookoCode;
+            }
+            
+            // Look for it in the HTML content as fallback
+            const scripts = document.querySelectorAll('script');
+            for (const script of scripts) {
+              const content = script.innerHTML;
+              
+              // Try various patterns
+              const patterns = [
+                /window\.patient\s*=\s*["']([^"']+)["']/,
+                /window\.current_user_glooko_code\s*=\s*["']([^"']+)["']/,
+                /"glooko_code":\s*"([^"]+)"/,
+                /"patient":\s*"([^"]+)"/,
+                /(eu-west-1-[a-zA-Z0-9\-]+)/,
+                /(us-east-1-[a-zA-Z0-9\-]+)/
+              ];
+              
+              for (const pattern of patterns) {
+                const match = content.match(pattern);
+                if (match && match[1] && match[1].includes('-')) {
+                  return match[1];
+                }
+              }
+            }
+            
+            return null;
+          });
+          
+          if (!patientId) {
+            throw new Error('Could not extract patient ID from dashboard');
+          }
+          
+          console.log("GLOOKO AUTH: Successfully extracted patient ID:", patientId);
+          
+          // Get cookies from the browser
+          const cookies = await page.cookies();
+          const cookieString = cookies.map(cookie => `${cookie.name}=${cookie.value}`).join('; ');
+          
+          console.log("GLOOKO AUTH: Got session cookies from Puppeteer");
+          
+          await browser.close();
+          
+          return {
+            cookies: cookieString,
+            user: {
+              authenticated: true,
+              userLogin: {
+                glookoCode: patientId
+              }
+            }
+          };
+          
+        } catch (error) {
+          if (browser) {
+            await browser.close();
+          }
+          console.log("GLOOKO AUTH: Puppeteer authentication failed:", error.message);
+          console.log("GLOOKO AUTH: Falling back to legacy method");
+          return impl.authFromCredentialsLegacy();
+        }
+      })();
+    },
+
+    authFromCredentialsLegacy ( ) {
+      console.log("GLOOKO AUTH: Using legacy authentication method");
+      
+      // Check if patient ID is manually configured
+      if (opts.glookoPatientId) {
+        console.log("GLOOKO AUTH: Manual patient ID configured, using web form login");
+        return impl.authFromCredentialsWebForm();
+      } else {
+        console.log("GLOOKO AUTH: Trying original API login method");
+        var payload = login_payload(opts);
+        return http.post(Defaults.apiLogin, payload).then((response) => {
+          console.log("GLOOKO AUTH: API login response:", response.status);
+          return { cookies: response.headers['set-cookie'][0], user: response.data };
+        }).catch((error) => {
+          console.log("GLOOKO AUTH: API login failed:", error.response?.status, error.message);
+          throw new Error('Unable to authenticate. Please add CONNECT_GLOOKO_PATIENT_ID=your-patient-id to your .env file, or install Puppeteer for automatic extraction.');
+        });
+      }
+    },
+
+    authFromCredentialsWebForm ( ) {
+      console.log("GLOOKO AUTH: Using web form authentication with manual patient ID");
+      console.log("GLOOKO AUTH: Step 1 - Getting login form for CSRF token from", webURL);
+      
+      // Step 1: Get login form to extract CSRF token
+      return webHttp.get(Defaults.loginForm).then((formResponse) => {
+        console.log("GLOOKO AUTH: Got login form, extracting CSRF token");
+        const csrf_token = extract_csrf_token(formResponse.data);
+        
+        if (!csrf_token) {
+          throw new Error('Could not extract CSRF token from login form');
+        }
+        console.log("GLOOKO AUTH: Extracted CSRF token");
+        
+        // Extract cookies from the form response to send with login POST
+        const formCookies = formResponse.headers['set-cookie'];
+        const cookieHeader = formCookies ? formCookies.map(cookie => cookie.split(';')[0]).join('; ') : '';
+        
+        console.log("GLOOKO AUTH: Step 2 - Posting login with CSRF token and cookies");
+        
+        // Step 2: POST login with form data, CSRF token, and cookies
+        const formData = form_login_payload(opts, csrf_token);
+        const loginHeaders = {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+          'Accept-Language': 'en-US,en;q=0.9',
+          'Cache-Control': 'max-age=0',
+          'Referer': webURL + Defaults.loginForm,
+          'Cookie': cookieHeader
+        };
+        
+        return webHttp.post(Defaults.login, formData, { headers: loginHeaders });
+      }).then((response) => {
+        console.log("GLOOKO AUTH SUCCESS - Status:", response.status);
+        const cookies = response.headers['set-cookie'];
+        if (cookies) {
+          const sessionCookie = cookies.join('; ');
+          
+          console.log("GLOOKO AUTH: Using manually configured patient ID:", opts.glookoPatientId);
+          return {
+            cookies: sessionCookie,
+            user: {
+              authenticated: true,
+              userLogin: {
+                glookoCode: opts.glookoPatientId
+              }
+            }
+          };
+        } else {
+          throw new Error('No session cookies received after login');
+        }
+      }).catch((error) => {
+        console.log("GLOOKO AUTH FAILED:");
+        console.log("  Status:", error.response?.status);
+        console.log("  Message:", error.message);
+        throw error;
       });
     },
     sessionFromAuth (auth) {
@@ -95,15 +345,20 @@ function glookoSource (opts, axios) {
       };
 
       function fetcher (endpoint) {
-        var headers = default_headers;
+        var headers = Object.assign({}, default_headers);
         headers["Cookie"] = session.cookies;
-        headers["Host"] = "eu.api.glooko.com";
+        // Let axios handle the Host header automatically
         headers["Sec-Fetch-Dest"] = "empty";
         headers["Sec-Fetch-Mode"] = "cors";
         headers["Sec-Fetch-Site"] = "same-site";
         console.log('GLOOKO FETCHER LOADING', endpoint);
+        console.log('GLOOKO FETCHER using base URL:', http.defaults.baseURL);
+        console.log('GLOOKO FETCHER headers:', Object.keys(headers));
         return http.get(endpoint, { headers, params })
-          .then((resp) => resp.data);
+          .then((resp) => {
+            console.log('GLOOKO FETCHER SUCCESS:', endpoint);
+            return resp.data;
+          });
       }
 
       // 2023-06-11T00:00:00.000Z
@@ -165,11 +420,13 @@ function glookoSource (opts, axios) {
       // TODO
     },
     transformData (batch) {
-      // TODO
       console.log('GLOOKO passing batch for transforming');
-      //console.log("TODO TRANSFORM", batch);
+      console.log('GLOOKO batch contains:', Object.keys(batch));
+      
       var treatments = helper.generate_nightscout_treatments(batch, opts.glookoTimezoneOffset);
-      return { entries: [ ], treatments };
+      var entries = helper.generate_nightscout_entries(batch, opts.glookoTimezoneOffset);
+      
+      return { entries, treatments };
     },
   };
   function tracker_for ( ) {
@@ -229,6 +486,7 @@ glookoSource.validate = function validate_inputs (input) {
     glookoServer: input.glookoServer,
     glookoEmail: input.glookoEmail,
     glookoPassword: input.glookoPassword,
+    glookoPatientId: input.glookoPatientId,
     glookoTimezoneOffset: offset,
     baseURL
   };

--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -32,7 +32,8 @@ var Defaults = {
 , LatestInsulins: '/api/v2/insulins'
 , LatestPumpBasals: '/api/v2/pumps/scheduled_basals'
 , LatestPumpBolus: '/api/v2/pumps/normal_boluses'
-, LatestCGMReadings: '/api/v2/cgm/readings'
+, LatestCGMReadings: '/api/v2/cgm/readings'  // Legacy v2 API (often empty)
+, GraphCGMReadings: '/api/v3/graph/data?patient=_PATIENT_&startDate=_STARTDATE_&endDate=_ENDDATE_&series[]=cgmHigh&series[]=cgmNormal&series[]=cgmLow&locale=en&insulinTooltips=true&filterBgReadings=true&splitByDay=false'  // Working Graph API with all parameters
 , PumpSettings: '/api/v2/external/pumps/settings'
 , v3API: '/api/v3/graph/data?patient=_PATIENT_&startDate=_STARTDATE_&endDate=_ENDDATE_&series[]=automaticBolus&series[]=basalBarAutomated&series[]=basalBarAutomatedMax&series[]=basalBarAutomatedSuspend&series[]=basalLabels&series[]=basalModulation&series[]=bgAbove400&series[]=bgAbove400Manual&series[]=bgHigh&series[]=bgHighManual&series[]=bgLow&series[]=bgLowManual&series[]=bgNormal&series[]=bgNormalManual&series[]=bgTargets&series[]=carbNonManual&series[]=cgmCalibrationHigh&series[]=cgmCalibrationLow&series[]=cgmCalibrationNormal&series[]=cgmHigh&series[]=cgmLow&series[]=cgmNormal&series[]=deliveredBolus&series[]=deliveredBolus&series[]=extendedBolusStep&series[]=extendedBolusStep&series[]=gkCarb&series[]=gkInsulin&series[]=gkInsulin&series[]=gkInsulinBasal&series[]=gkInsulinBolus&series[]=gkInsulinOther&series[]=gkInsulinPremixed&series[]=injectionBolus&series[]=injectionBolus&series[]=interruptedBolus&series[]=interruptedBolus&series[]=lgsPlgs&series[]=overrideAboveBolus&series[]=overrideAboveBolus&series[]=overrideBelowBolus&series[]=overrideBelowBolus&series[]=pumpAdvisoryAlert&series[]=pumpAlarm&series[]=pumpBasaliqAutomaticMode&series[]=pumpBasaliqManualMode&series[]=pumpCamapsAutomaticMode&series[]=pumpCamapsBluetoothTurnedOffMode&series[]=pumpCamapsBoostMode&series[]=pumpCamapsDailyTotalInsulinExceededMode&series[]=pumpCamapsDepoweredMode&series[]=pumpCamapsEaseOffMode&series[]=pumpCamapsExtendedBolusNotAllowedMode&series[]=pumpCamapsManualMode&series[]=pumpCamapsNoCgmMode&series[]=pumpCamapsNoPumpConnectivityMode&series[]=pumpCamapsPumpDeliverySuspendedMode&series[]=pumpCamapsUnableToProceedMode&series[]=pumpControliqAutomaticMode&series[]=pumpControliqExerciseMode&series[]=pumpControliqManualMode&series[]=pumpControliqSleepMode&series[]=pumpGenericAutomaticMode&series[]=pumpGenericManualMode&series[]=pumpOp5AutomaticMode&series[]=pumpOp5HypoprotectMode&series[]=pumpOp5LimitedMode&series[]=pumpOp5ManualMode&series[]=reservoirChange&series[]=scheduledBasal&series[]=setSiteChange&series[]=suggestedBolus&series[]=suggestedBolus&series[]=suspendBasal&series[]=temporaryBasal&series[]=unusedScheduledBasal&locale=en-GB'
 // ?sessionID=e59c836f-5aeb-4b95-afa2-39cf2769fede&minutes=1440&maxCount=1"
@@ -354,7 +355,14 @@ function glookoSource (opts, axios) {
         console.log('GLOOKO FETCHER LOADING', endpoint);
         console.log('GLOOKO FETCHER using base URL:', http.defaults.baseURL);
         console.log('GLOOKO FETCHER headers:', Object.keys(headers));
-        return http.get(endpoint, { headers, params })
+        
+        // Only add pagination params for v2 API endpoints, not Graph API
+        const requestOptions = { headers };
+        if (!endpoint.includes('/api/v3/graph/data')) {
+          requestOptions.params = params;
+        }
+        
+        return http.get(endpoint, requestOptions)
           .then((resp) => {
             console.log('GLOOKO FETCHER SUCCESS:', endpoint);
             return resp.data;
@@ -378,11 +386,18 @@ function glookoSource (opts, axios) {
         const myDate = new Date();
         const startDate = new Date(two_days_ago); // myDate.getTime() - 6 * 60 * 60 * 1000);
 
-        const url = endpoint + "?patient=" + session.user.userLogin.glookoCode
-         + "&startDate=" + startDate.toISOString()
-         + "&endDate=" + myDate.toISOString();
-
-        return url;
+        // Replace placeholders if they exist, otherwise append as query parameters
+        if (endpoint.includes('_PATIENT_')) {
+          return endpoint
+            .replace('_PATIENT_', session.user.userLogin.glookoCode)
+            .replace('_STARTDATE_', startDate.toISOString())
+            .replace('_ENDDATE_', myDate.toISOString());
+        } else {
+          const url = endpoint + "?patient=" + session.user.userLogin.glookoCode
+           + "&startDate=" + startDate.toISOString()
+           + "&endDate=" + myDate.toISOString();
+          return url;
+        }
       }
 
       return Promise.all([
@@ -391,16 +406,47 @@ function glookoSource (opts, axios) {
         //fetcher(constructUrl(Defaults.LatestInsulins)),
         fetcher(constructUrl(Defaults.LatestPumpBasals)),
         fetcher(constructUrl(Defaults.LatestPumpBolus)),
-        fetcher(constructUrl(Defaults.LatestCGMReadings)),
+        fetcher(constructUrl(Defaults.GraphCGMReadings)),
         //fetcher(constructUrl(Defaults.PumpSettings))
         ]).then(function (results) {
           //console.log(results);
+          
+          // Extract CGM readings from Graph API response
+          var cgmReadings = [];
+          if (results[2] && results[2].series) {
+            const { cgmHigh, cgmNormal, cgmLow } = results[2].series;
+            
+            // Combine all CGM readings from different series
+            [cgmHigh, cgmNormal, cgmLow].forEach(series => {
+              if (series && Array.isArray(series)) {
+                series.forEach(point => {
+                  if (point && point.timestamp && point.y) {
+                    // Graph API timestamps come in Finland time (UTC+3) but marked as UTC
+                    // Convert to actual UTC by subtracting 3 hours
+                    const moment = require('moment');
+                    const utcTimestamp = moment(point.timestamp).subtract(3, 'hours').toISOString();
+                    cgmReadings.push({
+                      timestamp: utcTimestamp,
+                      value: point.y,
+                      deviceModel: 'cgm'
+                    });
+                  }
+                });
+              }
+            });
+            
+            // Sort by timestamp
+            cgmReadings.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+          }
+          
+          console.log('GLOOKO Graph API: Extracted', cgmReadings.length, 'CGM readings');
+          
          var some = {
             //food: results[0].foods,
             //insulins: results[1].insulins,
             scheduledBasals: results[0].scheduledBasals,
             normalBoluses: results[1].normalBoluses,
-            readings: results[2].readings
+            readings: cgmReadings
             //settings: results[4].pumpSettings
          };
 

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "tough-cookie": "^4.1.3",
     "xstate": "^4.37.1",
     "yargs": "^17.7.1"
+  },
+  "optionalDependencies": {
+    "puppeteer": "^21.0.0"
   }
 }


### PR DESCRIPTION
Hello all,

I noticed the calls to Glooko's api v2 don't work anymore, returning 422 errors (malformed requests). The original login form scraping allows for authentication, but a headless chrome instance is required to execute the javascript that sets the cookies containing the patient ID when the dashboard view of Glooko is "displayed".

Then the CGM data gets pulled from the internal API to the dashboard, using the patient ID. 

So I used puppeteer to login, set the cookie, capture the patient ID and make the calls to the internal API for retrieving the CGM data and formatting it for Nightscout.

This fixed version retrieves correctly the CGM data and uploads it to NS, along with the temp basals and treatments stored in Glooko.

Notice that for **Dexcom G7 users, there is typically a 3 hour delay in CGM values**, since Glooko puls them from Clarity, not deom Dexcom Share !!!

For **CamAPS users, there seems to be a 60-90 min delay**, due to the fact that the mobile device sends data to the Glooko servers in the background (typical for Android and iOS devices), depending on battery, network, etc...)

This version requires work on the data timestamps, (UTC ?) and formatting the timestamps for uploading to NS. I seem to get future data...

<img width="808" height="602" alt="image" src="https://github.com/user-attachments/assets/330a8705-1d68-4a45-b361-0718db0a988b" />
