### PR TITLE
Fix LibreLinkUp API for October 2025 authentication changes

### DIFF
--- a/lib/sources/librelinkup.js
+++ b/lib/sources/librelinkup.js
@@ -1,6 +1,7 @@
 
 var qs = require('qs');
 var url = require('url');
+var crypto = require('crypto');
 
 const _LluApiEndpoints = {
     AE: "api-ae.libreview.io",
@@ -20,8 +21,8 @@ var Defaults = {
   Connections: '/llu/connections',
   Graph: '/llu/connections/',
   mime: 'application/json',
-  Version: '4.7.0',
-  Product: 'llu.ios',
+  Version: '4.16.0',
+  Product: 'llu.android',
 
 };
 var software = require('../../package.json');
@@ -74,8 +75,11 @@ function linkUpSource (opts, axios) {
         return elem.patientId == opts.linkUpPatientId;
       }
       var token = auth.data.authTicket.token;
+      var userId = auth.data.user.id;
+      var accountId = crypto.createHash('sha256').update(userId).digest('hex');
       var headers = {
-        'Authorization': [ 'Bearer', token ].join(' ')
+        'Authorization': [ 'Bearer', token ].join(' '),
+        'Account-Id': accountId
       };
       return http.get(Defaults.Connections, { headers }).then((resp) => {
         console.log("CONNECTIONS RESPONSE FROM LIBRELINKUP", resp.status, resp.headers, resp.data);
@@ -94,6 +98,7 @@ function linkUpSource (opts, axios) {
         }
         var result = connections[0];
         result.authTicket = auth.data.authTicket;
+        result.userId = auth.data.user.id;
         console.log("LIBRE SESSION FROM AUTH", result);
         return result;
 
@@ -109,8 +114,10 @@ function linkUpSource (opts, axios) {
       var lastUpdatedAt = last_glucose_at.toISOString( );
       var graph_url = [Defaults.Graph, session.patientId, '/graph'].join('');
       var token = session.authTicket.token;
+      var accountId = crypto.createHash('sha256').update(session.userId).digest('hex');
       var headers = {
-        'Authorization': `Bearer ${token}`
+        'Authorization': `Bearer ${token}`,
+        'Account-Id': accountId
       };
       return http.get(graph_url, { headers }).then((resp) => {
         console.log("RECEIVED LIBRE GRAPH DATA", resp.status, resp.headers, resp.data);
@@ -121,7 +128,6 @@ function linkUpSource (opts, axios) {
       var { status, data, ticket } = payload;
       var batch = data;
       // TODO: TRANSFORM
-      var last_updated = last_known.entries;
       function is_newer (elem) {
         if (!last_known) { return true; };
         return last_known.entries < new Date(elem.dateString);


### PR DESCRIPTION
## Summary

Fixes LibreLinkUp connection failures caused by Abbott's API changes in October 2025.

## Problem

Starting in October 2025, Abbott updated the LibreLinkUp API with new authentication requirements:
- New mandatory `Account-Id` header (SHA-256 hash of user.id)
- Updated version requirement to 4.16.0+
- Product identifier changed from `llu.ios` to `llu.android`

Without these changes, all LibreLinkUp connections fail with **403 Forbidden** errors during the authorization step.

## Changes

### Updated API version and product identifier
- `Defaults.Version`: `4.7.0` → `4.16.0`
- `Defaults.Product`: `llu.ios` → `llu.android`

### Added Account-Id header support
- Added `crypto` require for SHA-256 hashing
- Modified `sessionFromAuth()` to:
  - Extract `user.id` from auth response
  - Generate SHA-256 hash of user.id as `Account-Id`
  - Include `Account-Id` header in `/llu/connections` request
  - Store `userId` in session for later use
- Modified `dataFromSesssion()` to:
  - Generate `Account-Id` from stored `session.userId`
  - Include `Account-Id` header in graph data requests

## Testing

Tested with:
- US region LibreLinkUp account
- Follower account configuration
- Verified successful authentication and authorization (HTTP 200)
- Confirmed glucose data retrieval from LibreView API

## References

- Similar fixes required across the ecosystem (xDrip, GlucoDataHandler, etc.)
- API change confirmed by community reports in October 2025

This fix enables LibreLinkUp integration to work with the current Abbott API requirements.