### PR TITLE
fix(dexcomshare): surface auth failures, handle modern response shape, harden catch paths

### DIFF
--- a/lib/sources/dexcomshare.js
+++ b/lib/sources/dexcomshare.js
@@ -145,19 +145,36 @@ function dexcomshareSource (opts, axios) {
       , "accountName": opts.shareAccountName
       };
       return http.post(modDefaults.auth, body, { params, headers }).then((response) => {
-        return response.data;
+        // Dexcom Share's Authenticate endpoint can return either a bare UUID string
+        // (older accounts) or a JSON object that contains the accountId (newer/G7-era
+        // accounts). Normalize to the bare UUID string so downstream sessionFromAuth
+        // sends the correct shape.
+        var data = response.data;
+        if (data && typeof data === 'object' && data.accountId) {
+          return data.accountId;
+        }
+        return data;
       })
       .catch((err) => {
-        console.log("ERROR AUTHENTICATING ACCOUNT REQUEST", err.request);
-        console.log("ERROR AUTHENTICATING ACCOUNT RESPONSE", err.response.status, err.response.data);
-        return err;
+        var status = err && err.response && err.response.status;
+        var data = err && err.response && err.response.data;
+        console.log("ERROR AUTHENTICATING ACCOUNT", "status=" + status, "data=", data, "message=", err && err.message);
+        // Propagate the failure as a rejection so the state machine treats it as a
+        // real failure rather than silently passing an Error object downstream where
+        // it gets serialized into the next request body.
+        return Promise.reject(err);
       });
     },
     sessionFromAuth(account, settings) {
+      // Defensive: accept either a bare UUID string or a wrapper object so we are
+      // robust to both legacy and current Dexcom Authenticate response shapes.
+      var accountId = (account && typeof account === 'object' && account.accountId)
+        ? account.accountId
+        : account;
       var body = {
         "password": opts.sharePassword
       , "applicationId" : modDefaults.applicationId
-      , "accountId": account
+      , "accountId": accountId
       };
       var params = { applicationId: modDefaults.applicationId };
       var headers = { };
@@ -165,8 +182,10 @@ function dexcomshareSource (opts, axios) {
         return response.data;
       })
       .catch((err) => {
-        console.log("FAILED TO GET DEXCOM SHARE SESSION RESPONSE", err.response.status, err.response.headers, err.response.data);
-        return { status: err.response.status, headers: err.response.headers, data: error.response.data };
+        var status = err && err.response && err.response.status;
+        var data = err && err.response && err.response.data;
+        console.log("FAILED TO GET DEXCOM SHARE SESSION", "status=" + status, "data=", data, "message=", err && err.message);
+        return Promise.reject(err);
       });
     },
     dataFromSesssion(session, last_known) {
@@ -186,14 +205,17 @@ function dexcomshareSource (opts, axios) {
         return response.data;
       })
       .catch((err) => {
-        console.log("FAILED TO GET DEXCOM SHARE SESSION RESPONSE", err.response.status, err.response.headers, err.response.data);
-        return { status: err.response.status, headers: err.response.headers, data: error.response.data };
+        var status = err && err.response && err.response.status;
+        var data = err && err.response && err.response.data;
+        console.log("FAILED TO GET DEXCOM SHARE LATEST GLUCOSE", "status=" + status, "data=", data, "message=", err && err.message);
+        return Promise.reject(err);
       });
     },
     transformGlucose (data) {
-      // pass through
-      // TODO: delete $._id
-      if (!data) {
+      // Defensive: only map if we actually got an array back. Anything else (null,
+      // an error object from a failed fetch, an unexpected response shape) becomes
+      // an empty entries list rather than crashing the loop.
+      if (!Array.isArray(data)) {
         return { entries: [ ] };
       }
       return { entries: data.map(dex_to_entry) };


### PR DESCRIPTION
## Summary

Fixes five related bugs in `lib/sources/dexcomshare.js` that together cause Dexcom Share authentication failures to never surface, produce misleading downstream 500s, and crash the catch paths on any non-HTTP error.

Field symptom (especially common for G7 accounts): the plugin reports `RUNNING 0 failures 0` indefinitely and never stores new entries, even though logs claim `type: 'AUTHENTICATED'`. The actual underlying error from Dexcom is being swallowed.

## Bugs fixed

1. **`authFromCredentials` returns the error object as a resolved value.** The state machine treats it as a successful authentication and passes the `Error` object into `sessionFromAuth` as `accountId`. Dexcom then responds with `500 InvalidArgument: cannot deserialize java.util.UUID from Object value`, hiding the real upstream cause (typically `AccountPasswordInvalid`). **Fixed** by re-rejecting the promise so the state machine runs its `AUTHENTICATION_ERROR` path.
2. **Modern Authenticate response shape not handled.** Newer Dexcom accounts (observed on G7) get back `{accountId: "<uuid>"}` from `AuthenticatePublisherAccount` rather than a bare UUID string. The plugin sent the wrapper object as the next request's `accountId`. **Fixed** by normalizing to the bare UUID in `authFromCredentials` and accepting either shape defensively in `sessionFromAuth`.
3. **`error.response.data` typo** in two catch blocks (`sessionFromAuth`, `dataFromSesssion`). The variable in scope is `err`. Catch block crashes with `ReferenceError` whenever entered. **Fixed** by using the right identifier.
4. **`err.response` dereferenced without an existence check.** Crashes the catch path with `TypeError` on any non-HTTP error (DNS, ECONNRESET, TLS, timeout). **Fixed** with defensive access.
5. **`transformGlucose` does `data.map()` on whatever it receives**, including non-array failure objects (especially with bug #1 papering over auth failures). **Fixed** by guarding with `Array.isArray`.

The new error-log format also surfaces the Dexcom response body + the AxiosError message on a single line, which made diagnosing this PR's root cause take minutes instead of hours.

## Testing

Validated against a live Dexcom G7 patient account on Heroku. Before the patch, the plugin looped silently with stale data and confusing logs. After the patch, the plugin surfaces `AccountPasswordInvalid` directly from Dexcom's response — a real auth issue the user can act on.

## Notes

- No new dependencies, no API changes, no test breakage expected.
- The error-shape change in `dataFromSesssion`'s catch (now `Promise.reject` instead of a wrapped object) is consistent with the other two paths and aligns with what the state machine seems to expect (it already handles rejection via its `onError` transitions).

Closes any open issue tracking the "0 entries forever" behavior or the cryptic UUID-deserialization 500s.
