### PR TITLE
fix(glooko): use per-collection cursors and redact private logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,10 +51,13 @@ function manage (env, ctx) {
       ctx.bootErrors.push(...validated.errors);
   }
 
-  console.log("INPUT PARAMS", spec, validated.config);
+  console.log("INPUT PARAMS", spec, {
+    kind: validated.config.kind,
+    baseURL: validated.config.baseURL
+  });
 
   if (!validated.ok) {
-    console.log("Invalid, disabling nightscout-connect", validated);
+    console.log("Invalid, disabling nightscout-connect", validated.errors);
     return;
   }
   var impl = driver(validated.config, axios);

--- a/lib/outputs/internal.js
+++ b/lib/outputs/internal.js
@@ -85,12 +85,16 @@ function persistent (config, ctx) {
   }
 
   function persists (batch) {
-    console.log("INTERNAL PERSISTENCE", batch);
     var { entries, treatments, profiles, devicestatus } = batch;
     entries = entries || [ ];
     treatments = treatments || [ ];
     profiles = profiles || [ ];
     devicestatus = devicestatus || [ ];
+    console.log("INTERNAL PERSISTENCE",
+      entries.length, "entries,",
+      treatments.length, "treatments,",
+      profiles.length, "profiles,",
+      devicestatus.length, "devicestatus");
     /*
     if (!batch.entries.length) {
       return Promise.resolve(known);
@@ -115,11 +119,11 @@ function persistent (config, ctx) {
       record_collection('devicestatus', devicestatus),
       record_collection('profile', profiles),
       recorded]).then(function (settled) {
-      console.log("ALL SETTLED INTERNAL PERSIST", settled, arguments);
+      console.log("ALL SETTLED INTERNAL PERSIST", settled.length, "operations");
       return known;
 
-    }).catch(( ) => {
-      console.log("PERSISTED INTERNAL ERRORED", arguments);
+    }).catch((err) => {
+      console.log("PERSISTED INTERNAL ERRORED", err && err.message);
       return known;
     });
 

--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -257,7 +257,7 @@ function glookoSource (opts, axios) {
       function apiLogin ( ) {
       var payload = login_payload(opts);
       return http.post(Defaults.login, payload).then((response) => {
-        console.log("GLOOKO AUTH", response.headers, response.data);
+        console.log("GLOOKO AUTH successful");
           assertNoTwoFactorRequired(response.data);
           return { cookies: extractSetCookie(response.headers), user: response.data };
       });
@@ -303,26 +303,26 @@ function glookoSource (opts, axios) {
     },
     dataFromSesssion (session, last_known) {
       var two_days_ago = new Date( ).getTime( ) - (2 * 24 * 60 * 60 * 1000);
-      var last_mills = Math.max(two_days_ago, (last_known && last_known.entries) ? last_known.entries.getTime( ) : two_days_ago);
-      var last_glucose_at = new Date(last_mills);
-      var maxCount = Math.ceil(((new Date( )).getTime( ) - last_mills) / (1000 * 60 * 5));
-      var minutes = 5 * maxCount;
-      var lastUpdatedAt = last_glucose_at.toISOString( );
-      var body = { };
-      var params = {
-        lastGuid: Defaults.lastGuid,
-        lastUpdatedAt,
-        limit: maxCount,
-      };
+      function paramsFor (collection) {
+        var bookmark = last_known && last_known[collection];
+        var last_mills = Math.max(two_days_ago, bookmark ? bookmark.getTime( ) : two_days_ago);
+        return {
+          lastGuid: Defaults.lastGuid,
+          lastUpdatedAt: new Date(last_mills).toISOString( ),
+          limit: Math.ceil(((new Date( )).getTime( ) - last_mills) / (1000 * 60 * 5))
+        };
+      }
+      var treatmentParams = paramsFor('treatments');
+      var entryParams = paramsFor('entries');
 
-      function fetcher (endpoint) {
+      function fetcher (endpoint, params) {
         var headers = { ...default_headers };
         headers["Cookie"] = session.cookies;
         headers["Host"] = baseHost;
         headers["Sec-Fetch-Dest"] = "empty";
         headers["Sec-Fetch-Mode"] = "cors";
         headers["Sec-Fetch-Site"] = "same-site";
-        console.log('GLOOKO FETCHER LOADING', endpoint);
+        console.log('GLOOKO FETCHER LOADING', endpoint.split('?')[0]);
         return http.get(endpoint, { headers, params })
           .then((resp) => resp.data);
       }
@@ -363,9 +363,9 @@ function glookoSource (opts, axios) {
             //fetcher(v3APIURL)
             //fetcher(constructUrl(Defaults.LatestFoods)),
             //fetcher(constructUrl(Defaults.LatestInsulins)),
-            fetcher(pumpBasalsUrl),
-            fetcher(pumpBolusUrl),
-            fetcher(cgmReadingsUrl),
+            fetcher(pumpBasalsUrl, treatmentParams),
+            fetcher(pumpBolusUrl, treatmentParams),
+            fetcher(cgmReadingsUrl, entryParams),
             //fetcher(constructUrl(Defaults.PumpSettings))
           ]
         : [
@@ -399,14 +399,14 @@ function glookoSource (opts, axios) {
           }
           var patientCode = getGlookoCode(session);
           if (!patientCode) {
-            return fetcher('/api/v3/session/users')
+            return fetcher('/api/v3/session/users', entryParams)
               .then((profile) => ({ ...some, userProfile: profile }))
               .then((withProfile) => {
                 var profileCode = withProfile.userProfile && (withProfile.userProfile.currentUser && withProfile.userProfile.currentUser.glookoCode || withProfile.userProfile.currentPatient && withProfile.userProfile.currentPatient.glookoCode);
                 if (!profileCode) {
                   return withProfile;
                 }
-                return fetcher(constructV3GraphUrl(profileCode, new Date(two_days_ago), new Date( )))
+                return fetcher(constructV3GraphUrl(profileCode, new Date(two_days_ago), new Date( )), entryParams)
                   .then((v3Graph) => ({ ...withProfile, v3Graph }));
               })
               .catch((err) => {
@@ -414,7 +414,7 @@ function glookoSource (opts, axios) {
                 return some;
               });
           }
-          return fetcher(constructV3GraphUrl(patientCode, new Date(two_days_ago), new Date( )))
+          return fetcher(constructV3GraphUrl(patientCode, new Date(two_days_ago), new Date( )), entryParams)
             .then((v3Graph) => ({ ...some, v3Graph }))
             .catch((err) => {
               console.log('GLOOKO V3 GRAPH FETCH FAILED', err && err.message);

--- a/test/glooko.test.js
+++ b/test/glooko.test.js
@@ -441,3 +441,89 @@ test('Glooko transform tolerates missing readings', () => {
 
   assert.deepEqual(source.transformData({}), { entries: [], treatments: [] });
 });
+
+test('Glooko incremental fetch uses the treatment bookmark when glucose is newer', async () => {
+  const calls = [];
+  const treatmentBookmark = new Date(Date.now() - (3 * 60 * 60 * 1000));
+  const entryBookmark = new Date(Date.now() - (5 * 60 * 1000));
+  const source = glookoSource({
+    glookoEmail: 'user@example.com',
+    glookoPassword: 'test-password',
+    baseURL: 'https://api.glooko.com'
+  }, fakeAxios((call) => {
+    calls.push(call);
+    if (call.path.startsWith('/api/v2/pumps/scheduled_basals')) {
+      return Promise.resolve({ data: { scheduledBasals: [] } });
+    }
+    if (call.path.startsWith('/api/v2/pumps/normal_boluses')) {
+      return Promise.resolve({ data: { normalBoluses: [] } });
+    }
+    if (call.path.startsWith('/api/v2/cgm/readings')) {
+      return Promise.resolve({ data: { readings: [] } });
+    }
+    throw new Error('unexpected path ' + call.path);
+  }));
+
+  await source.dataFromSesssion({
+    cookies: '_logbook-web_session=test-session',
+    user: { userLogin: { glookoCode: 'test-patient' } }
+  }, {
+    entries: entryBookmark,
+    treatments: treatmentBookmark
+  });
+
+  assert.equal(calls.length, 3);
+  for (const call of calls) {
+    const isTreatmentRequest = call.path.startsWith('/api/v2/pumps/');
+    const expectedBookmark = isTreatmentRequest ? treatmentBookmark : entryBookmark;
+    assert.equal(call.options.params.lastUpdatedAt, expectedBookmark.toISOString());
+    if (isTreatmentRequest) {
+      assert.ok(call.options.params.limit >= 35, `expected a treatment-sized window, got ${call.options.params.limit}`);
+    } else {
+      assert.ok(call.options.params.limit <= 2, `expected an entry-sized window, got ${call.options.params.limit}`);
+    }
+  }
+});
+
+test('Glooko authentication and fetch logs omit session and patient identifiers', async () => {
+  const originalLog = console.log;
+  const logged = [];
+  console.log = (...args) => logged.push(args.map((arg) => {
+    if (typeof arg === 'string') return arg;
+    try { return JSON.stringify(arg); } catch (_) { return String(arg); }
+  }).join(' '));
+
+  try {
+    const source = glookoSource({
+      glookoEmail: 'user@example.com',
+      glookoPassword: 'test-password',
+      baseURL: 'https://api.glooko.com'
+    }, fakeAxios((call) => {
+      if (call.method === 'post') {
+        return Promise.resolve({
+          headers: { 'set-cookie': ['_logbook-web_session=private-cookie; path=/'] },
+          data: { userLogin: { glookoCode: 'private-patient-code' } }
+        });
+      }
+      if (call.path.startsWith('/api/v2/pumps/scheduled_basals')) {
+        return Promise.resolve({ data: { scheduledBasals: [] } });
+      }
+      if (call.path.startsWith('/api/v2/pumps/normal_boluses')) {
+        return Promise.resolve({ data: { normalBoluses: [] } });
+      }
+      if (call.path.startsWith('/api/v2/cgm/readings')) {
+        return Promise.resolve({ data: { readings: [] } });
+      }
+      throw new Error('unexpected path ' + call.path);
+    }));
+
+    const session = await source.authFromCredentials();
+    await source.dataFromSesssion(session, null);
+  } finally {
+    console.log = originalLog;
+  }
+
+  const output = logged.join('\n');
+  assert.doesNotMatch(output, /private-cookie/);
+  assert.doesNotMatch(output, /private-patient-code/);
+});

--- a/test/privacy-logging.test.js
+++ b/test/privacy-logging.test.js
@@ -1,0 +1,66 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const test = require('node:test');
+
+const manage = require('../index');
+const internalOutput = require('../lib/outputs/internal');
+
+function captureLogs (run) {
+  const originalLog = console.log;
+  const logged = [];
+  console.log = (...args) => logged.push(args.map((arg) => {
+    if (typeof arg === 'string') return arg;
+    try { return JSON.stringify(arg); } catch (_) { return String(arg); }
+  }).join(' '));
+
+  try {
+    return { result: run(), logged };
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+test('configuration logs omit source credentials', () => {
+  const ctx = {
+    bootErrors: [],
+    bus: new EventEmitter()
+  };
+
+  const { logged } = captureLogs(() => manage({
+    extendedSettings: {
+      connect: {
+        source: 'glooko',
+        glookoPassword: 'private-password-marker'
+      }
+    }
+  }, ctx));
+
+  assert.doesNotMatch(logged.join('\n'), /private-password-marker/);
+});
+
+test('internal output logs collection counts instead of raw batches', async () => {
+  const ctx = { bus: new EventEmitter() };
+  const output = internalOutput({}, ctx);
+  const originalLog = console.log;
+  const logged = [];
+  console.log = (...args) => logged.push(args.map((arg) => {
+    if (typeof arg === 'string') return arg;
+    try { return JSON.stringify(arg); } catch (_) { return String(arg); }
+  }).join(' '));
+
+  try {
+    await output({
+      entries: [],
+      treatments: [],
+      profiles: [],
+      devicestatus: [],
+      privateMarker: 'private-medical-batch-marker'
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.doesNotMatch(logged.join('\n'), /private-medical-batch-marker/);
+  assert.match(logged.join('\n'), /0 entries/);
+  assert.match(logged.join('\n'), /0 treatments/);
+});


### PR DESCRIPTION
## Summary

- use the Nightscout treatment bookmark for Glooko pump basal/bolus requests
- keep using the entry bookmark for Glooko CGM requests
- stop logging source credentials, authentication responses, patient-bearing request URLs, and raw persistence batches
- add regression coverage for the cursor selection and privacy boundaries

## Situation encountered

We diagnosed this on a Nightscout deployment that runs a current CGM source alongside the experimental Glooko connector. The connector was polling on its expected five-minute cadence, and direct comparison showed that Glooko had newer pump treatment records which were still absent from Nightscout.

The important state was that `last_known.entries` was close to real time because glucose ingestion was healthy, while `last_known.treatments` was older. `dataFromSesssion` built Glooko's `lastUpdatedAt` and `limit` from the entry bookmark for every endpoint. The newer glucose timestamp therefore collapsed the pump request window even though treatment ingestion was behind, so queued basal/bolus records could be skipped on every poll.

Using the treatment bookmark for pump endpoints allowed the missing backlog to be returned on the next cycle. A source-to-database comparison by stable record identifier then found no missing pump boluses. This PR generalizes that operational fix without making Glooko CGM inefficient: pump basal/bolus requests use `last_known.treatments`, while CGM and graph requests retain `last_known.entries`.

During the same investigation, normal Docker logs were found to contain several categories of private data:

- the validated source configuration, including account credentials
- Glooko authentication response headers and bodies, including session cookies and account/patient identifiers
- request URLs containing the Glooko patient code
- complete Nightscout batches and persistence results, including medical records

The replacement logs retain useful status, route, and collection-count information without emitting those payloads. No production credentials, identifiers, or medical values are included in this PR or its fixtures.

## Regional endpoint context

The deployed 0.0.12 package also had a hard-coded EU `Host` header that conflicted with a successfully selected non-EU API base URL. Current `main` already derives `Host` from `baseURL` and has a regional-host regression assertion, so this PR deliberately does not duplicate that fix.

## Tests

- Added a regression where glucose is five minutes old but treatments are three hours old; pump requests must use the treatment cursor while CGM uses the entry cursor.
- Added log-capture regressions proving that credentials, cookies, patient codes, and raw batches are absent.
- `npm test` passes: 51 tests, 0 failures.

## Risk and compatibility

The existing 48-hour fallback remains unchanged when a collection has no bookmark. Authentication, conversion, and persistence behavior are unchanged; only per-endpoint cursor selection and log detail are affected.
